### PR TITLE
Add requestHttps

### DIFF
--- a/packages/bs-node-ext/src/NodeExtHttp.rei
+++ b/packages/bs-node-ext/src/NodeExtHttp.rei
@@ -260,3 +260,9 @@ external request :
   (HttpRequestOpts.t, ~callback: Js.t(incomingMessage) => unit=?, unit) =>
   Js.t(clientRequest) =
   "";
+
+[@bs.module "https"]
+external requestHttps :
+  (HttpRequestOpts.t, ~callback: Js.t(incomingMessage) => unit=?, unit) =>
+  Js.t(clientRequest) =
+  "request";


### PR DESCRIPTION
Any lib will eventually need the option to use https.

I didn't duplicate `getWithOptions`. For maintenance it might be best to remove it; I don't think anyone will use node's http interface directly. Instead, other libraries will build on top, and `getWithOptions` is not as useful in that regard.