### PR TITLE
Add unsafeDataOutputToString

### DIFF
--- a/packages/bs-node-ext/src/NodeExtStreamCast.re
+++ b/packages/bs-node-ext/src/NodeExtStreamCast.re
@@ -17,3 +17,6 @@ let classifyDataOutput = (bufOrStr: dataOut) : bufferClassification =>
     | _ => JsType(classified)
     };
   };
+
+let unsafeDataOutputToString = (bufOrStr: dataOut) =>
+  Js.String.make(bufOrStr);


### PR DESCRIPTION
I'm not sure if this is the best way to do it. I was trying to collect a body response in the standard node manner and could not cast a chunk to a string. I know it's safe because I set the encoding beforehand. Is there a better way? Here is my code.

```js
module Stream = NodeExtHttp.NodeExtStream.ReadableStream;

let go = (resolve) => (res) => {
  let body = ref("");
  res
  |> Stream.setEncoding("utf8")
  |> Stream.on(`data(chunk => {
      body := body^ ++ NodeExtStreamCast.unsafeDataOutputToString(chunk);
    }))
  |> Stream.onEnd(() => {
      resolve(AeroResult.Ok(body^))
    })
};
```