### PR TITLE
Fix writeHead external

### DIFF
--- a/packages/bs-node-ext/src/NodeExtHttp.rei
+++ b/packages/bs-node-ext/src/NodeExtHttp.rei
@@ -161,8 +161,18 @@ module ServerResponse: {
   external writeHead :
     (
       Js.t(#serverResponse),
-      ~status: int,
-      ~message: string=?,
+      int,
+      ~headers: Js.Dict.t(string)=?,
+      unit
+    ) =>
+    unit =
+    "";
+  [@bs.send]
+  external writeHeadWithStatusMessage :
+    (
+      Js.t(#serverResponse),
+      int,
+      string,
       ~headers: Js.Dict.t(string)=?,
       unit
     ) =>


### PR DESCRIPTION
As it turns out, `res.writeHead(200, undefined, headers)` does *not* write headers in a node server response. Node seems to be checking for a falsey second argument instead of argument count, so `headers` is ignored when the second arg is `undefined`. However, `res.writeHead(200, headers)` works as expected.

I added a second external for those who need to also write a status message. This is a breaking change, but it was broken in the first place, so... :) Also, status code is required in `writeHead` so I went ahead and made that a required first argument.